### PR TITLE
Fix issue with settingModal undefine warnings

### DIFF
--- a/frontend/src/components/playground/index.tsx
+++ b/frontend/src/components/playground/index.tsx
@@ -139,10 +139,15 @@ function Playground() {
     }
     useEffect(() => {
         const handleClickOutside = (event) => {
+            // Check if settingModal and settingIcon are defined and contain the event target
             if (!(settingModal.current && settingModal.current.contains(event.target)) && !(settingIcon.current && settingIcon.current.contains(event.target))) {
-                settingModal.current.style.display = 'none';
+                // Additional check to ensure settingModal.current is defined before accessing its style
+                if (settingModal.current) {
+                    settingModal.current.style.display = 'none';
+                }
             }
         };
+    
         document.addEventListener('mousemove', handleClickOutside);
         return () => {
             document.removeEventListener('mousemove', handleClickOutside);


### PR DESCRIPTION
# Pull Request Template

## PR Description

Please provide a background of this PR and its purpose here.

Fixed an error in the playground component that occurred when settingModal.current was undefined during a mousemove event

## Linked Issue

If this PR addresses any issues, please mention them here. For example: Resolves #123

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance enhancement
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other, please describe:

## Checklist

Before submitting this PR, please make sure:

- [x] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md) guidelines.
- [x] I have tested my changes locally to ensure they are effective.
- [x] I have updated the necessary documentation (if applicable).

## Additional Information

Provide any other important information about this PR here.

![image](https://github.com/TaskingAI/TaskingAI/assets/32628248/8631ab39-bab0-48f7-86f1-3c5ac03e2ce7)


