### PR TITLE
feat: supports json mode for multiple chat completion model providers

### DIFF
--- a/inference/providers/anthropic/resources/models/claude-2.0.yml
+++ b/inference/providers/anthropic/resources/models/claude-2.0.yml
@@ -17,6 +17,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 pricing:
   input_token: 8.0

--- a/inference/providers/anthropic/resources/models/claude-2.1.yml
+++ b/inference/providers/anthropic/resources/models/claude-2.1.yml
@@ -17,6 +17,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 pricing:
   input_token: 8.0

--- a/inference/providers/anthropic/resources/models/claude-3-haiku.yml
+++ b/inference/providers/anthropic/resources/models/claude-3-haiku.yml
@@ -17,6 +17,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 pricing:
   input_token: 0.25

--- a/inference/providers/anthropic/resources/models/claude-3-opus.yml
+++ b/inference/providers/anthropic/resources/models/claude-3-opus.yml
@@ -17,6 +17,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 pricing:
   input_token: 15.0

--- a/inference/providers/anthropic/resources/models/claude-3-sonnet.yml
+++ b/inference/providers/anthropic/resources/models/claude-3-sonnet.yml
@@ -17,6 +17,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 pricing:
   input_token: 3.0

--- a/inference/providers/anthropic/resources/models/claude-instant-1.2.yml
+++ b/inference/providers/anthropic/resources/models/claude-instant-1.2.yml
@@ -17,6 +17,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 pricing:
   input_token: 0.8

--- a/inference/providers/anthropic/resources/models/wildcard.yml
+++ b/inference/providers/anthropic/resources/models/wildcard.yml
@@ -12,6 +12,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 pricing:
   input_token: 0

--- a/inference/providers/google_gemini/chat_completion.py
+++ b/inference/providers/google_gemini/chat_completion.py
@@ -113,6 +113,11 @@ def _build_google_gemini_chat_completion_payload(
             else:
                 generation_config[key] = value
 
+    if configs.response_format:
+        generation_config.pop("response_format", None)
+        if configs.response_format == "json_object":
+            generation_config["response_mime_type"] = "application/json"
+
     payload = {"contents": formatted_messages, "generationConfig": generation_config}
     if functions:
         payload["tools"] = [{"functionDeclarations": [f.model_dump() for f in functions]}]

--- a/inference/providers/google_gemini/resources/models/gemini-1.5-pro.yml
+++ b/inference/providers/google_gemini/resources/models/gemini-1.5-pro.yml
@@ -16,6 +16,7 @@ config_schemas:
   - config_id: top_k
   - config_id: max_tokens
   - config_id: stop
+  - config_id: response_format
 
 
 pricing:

--- a/inference/providers/google_gemini/resources/models/gemini-pro-vision.yml
+++ b/inference/providers/google_gemini/resources/models/gemini-pro-vision.yml
@@ -17,7 +17,6 @@ config_schemas:
   - config_id: max_tokens
   - config_id: stop
 
-
 pricing:
   input_token: 0
   output_token: 0

--- a/inference/providers/google_gemini/resources/models/gemini-pro.yml
+++ b/inference/providers/google_gemini/resources/models/gemini-pro.yml
@@ -17,7 +17,6 @@ config_schemas:
   - config_id: max_tokens
   - config_id: stop
 
-
 pricing:
   input_token: 0.0005
   output_token: 0.0015

--- a/inference/providers/mistralai/resources/models/mistral-large.yml
+++ b/inference/providers/mistralai/resources/models/mistral-large.yml
@@ -12,6 +12,7 @@ config_schemas:
   - config_id: temperature
   - config_id: top_p
   - config_id: max_tokens
+  - config_id: response_format
 
 pricing:
  input_token: 8

--- a/inference/providers/mistralai/resources/models/mistral-medium.yml
+++ b/inference/providers/mistralai/resources/models/mistral-medium.yml
@@ -12,6 +12,7 @@ config_schemas:
   - config_id: temperature
   - config_id: top_p
   - config_id: max_tokens
+  - config_id: response_format
 
 pricing:
   input_token: 2.7

--- a/inference/providers/mistralai/resources/models/mistral-small.yml
+++ b/inference/providers/mistralai/resources/models/mistral-small.yml
@@ -12,6 +12,7 @@ config_schemas:
   - config_id: temperature
   - config_id: top_p
   - config_id: max_tokens
+  - config_id: response_format
 
 pricing:
   input_token: 2

--- a/inference/providers/mistralai/resources/models/open-mistral-7b.yml
+++ b/inference/providers/mistralai/resources/models/open-mistral-7b.yml
@@ -12,6 +12,7 @@ config_schemas:
   - config_id: temperature
   - config_id: top_p
   - config_id: max_tokens
+  - config_id: response_format
 
 pricing:
  input_token: 0.25

--- a/inference/providers/mistralai/resources/models/open-mixtral-8x22b.yml
+++ b/inference/providers/mistralai/resources/models/open-mixtral-8x22b.yml
@@ -12,6 +12,7 @@ config_schemas:
   - config_id: temperature
   - config_id: top_p
   - config_id: max_tokens
+  - config_id: response_format
 
 pricing:
  input_token: 2

--- a/inference/providers/mistralai/resources/models/open-mixtral-8x7b.yml
+++ b/inference/providers/mistralai/resources/models/open-mixtral-8x7b.yml
@@ -12,6 +12,7 @@ config_schemas:
   - config_id: temperature
   - config_id: top_p
   - config_id: max_tokens
+  - config_id: response_format
 
 pricing:
  input_token: 0.7

--- a/inference/providers/openai/chat_completion.py
+++ b/inference/providers/openai/chat_completion.py
@@ -64,10 +64,21 @@ def _build_openai_chat_completion_payload(
         "model": provider_model_id,
         "stream": stream,
     }
+
     config_dict = configs.model_dump()
     for key, value in config_dict.items():
         if value is not None:
             payload[key] = value
+
+    if configs.response_format:
+        payload["response_format"] = {"type": configs.response_format}
+
+        if configs.response_format == "json_object":
+
+            if payload["messages"][0]["role"] == "system":
+                payload["messages"][0]["content"] = f"{payload['messages'][0]['content']} You are designed to output JSON."
+            else:
+                payload["messages"].insert(0, {"role": "system", "content": "You are designed to output JSON."})
 
     if "max_tokens" not in payload and "vision" in provider_model_id:
         # OpenAI currently set a low max_tokens default, so we need to override it

--- a/inference/providers/openai/resources/models/gpt-3.5-turbo-16k.yml
+++ b/inference/providers/openai/resources/models/gpt-3.5-turbo-16k.yml
@@ -16,6 +16,7 @@ config_schemas:
   - config_id: top_p
   - config_id: max_tokens
   - config_id: stop
+  - config_id: seed
 
 pricing:
   input_token: 0.0010

--- a/inference/providers/openai/resources/models/gpt-3.5-turbo.yml
+++ b/inference/providers/openai/resources/models/gpt-3.5-turbo.yml
@@ -16,6 +16,8 @@ config_schemas:
   - config_id: top_p
   - config_id: max_tokens
   - config_id: stop
+  - config_id: seed
+  - config_id: response_format
 
 pricing:
   input_token: 0.0005

--- a/inference/providers/openai/resources/models/gpt-4-turbo.yml
+++ b/inference/providers/openai/resources/models/gpt-4-turbo.yml
@@ -16,6 +16,8 @@ config_schemas:
   - config_id: top_p
   - config_id: max_tokens
   - config_id: stop
+  - config_id: seed
+  - config_id: response_format
 
 pricing:
   input_token: 0.01

--- a/inference/providers/openai/resources/models/gpt-4-vision.yml
+++ b/inference/providers/openai/resources/models/gpt-4-vision.yml
@@ -17,6 +17,7 @@ config_schemas:
   - config_id: top_p
   - config_id: max_tokens
   - config_id: stop
+  - config_id: seed
 
 pricing:
   input_token: 0.01

--- a/inference/providers/openai/resources/models/gpt-4.yml
+++ b/inference/providers/openai/resources/models/gpt-4.yml
@@ -16,6 +16,7 @@ config_schemas:
   - config_id: top_p
   - config_id: max_tokens
   - config_id: stop
+  - config_id: seed
 
 pricing:
   input_token: 0.03

--- a/inference/providers/openai/resources/models/gpt-4o.yml
+++ b/inference/providers/openai/resources/models/gpt-4o.yml
@@ -17,6 +17,8 @@ config_schemas:
   - config_id: top_p
   - config_id: max_tokens
   - config_id: stop
+  - config_id: seed
+  - config_id: response_format
 
 pricing:
   input_token: 0.005

--- a/inference/providers/togetherai/chat_completion.py
+++ b/inference/providers/togetherai/chat_completion.py
@@ -59,6 +59,17 @@ def _build_togetherai_chat_completion_payload(
     for key, value in config_dict.items():
         if value is not None:
             payload[key] = value
+
+    if configs.response_format:
+        payload["response_format"] = {"type": configs.response_format}
+
+        if configs.response_format == "json_object":
+
+            if payload["messages"][0]["role"] == "system":
+                payload["messages"][0]["content"] = f"{payload['messages'][0]['content']} You are designed to output JSON."
+            else:
+                payload["messages"].insert(0, {"role": "system", "content": "You are designed to output JSON."})
+
     if function_call:
         if function_call in ["none", "auto"]:
             payload["tool_choice"] = function_call

--- a/inference/providers/togetherai/resources/models/mistralai-Mistral-7B-Instruct-v0.1.yml
+++ b/inference/providers/togetherai/resources/models/mistralai-Mistral-7B-Instruct-v0.1.yml
@@ -15,6 +15,7 @@ config_schemas:
   - config_id: max_tokens
   - config_id: stop
   - config_id: top_k
+  - config_id: response_format
 
 pricing:
   input_token: 0.2

--- a/inference/providers/togetherai/resources/models/mistralai-Mixtral-8x7B-Instruct-v0.1.yml
+++ b/inference/providers/togetherai/resources/models/mistralai-Mixtral-8x7B-Instruct-v0.1.yml
@@ -15,6 +15,7 @@ config_schemas:
   - config_id: max_tokens
   - config_id: stop
   - config_id: top_k
+  - config_id: response_format
 
 pricing:
   input_token: 0.6

--- a/inference/providers/togetherai/resources/models/togethercomputer-CodeLlama-34b-Instruct.yml
+++ b/inference/providers/togetherai/resources/models/togethercomputer-CodeLlama-34b-Instruct.yml
@@ -15,6 +15,7 @@ config_schemas:
   - config_id: max_tokens
   - config_id: stop
   - config_id: top_k
+  - config_id: response_format
 
 pricing:
   input_token: 0.776

--- a/inference/test/test_chat_completion.py
+++ b/inference/test/test_chat_completion.py
@@ -1,6 +1,7 @@
 import allure
 import pytest
 import asyncio
+import json
 from test.utils.utils import sse_stream
 from test.setting import Config
 from test.inference_service.inference import chat_completion
@@ -560,3 +561,105 @@ class TestChatCompletion:
         assert res_json.get("data").get("message").get("role") == "assistant"
         assert res_json.get("data").get("message").get("content") is not None
         assert res_json.get("data").get("message").get("function_calls") is None
+        
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "test_data",
+        generate_test_cases("chat_completion") + generate_wildcard_test_cases("chat_completion"),
+        ids=lambda d: d["model_schema_id"],
+    )
+    @pytest.mark.flaky(reruns=5, reruns_delay=1)
+    async def test_chat_completion_by_normal_response_format(self, test_data):
+        if "response_format" not in test_data["allowed_configs"]:
+            pytest.skip("Skip the test case without response_format.")
+        model_schema_id = test_data["model_schema_id"]
+        message = [
+        {
+            "role": "user",
+            "content": "What does 42 mean"
+        }
+    ]
+        if "debug-error" in model_schema_id or "azure" in model_schema_id or "hugging_face" in model_schema_id:
+            pytest.skip("Skip the test case with debug-error.")
+        configs = {
+            "temperature": 0.5,
+            "response_format": "json_object"
+        }
+        request_data = {
+            "model_schema_id": model_schema_id,
+            "messages": message,
+            "stream": False,
+            "configs": configs,
+        }
+        if "wildcard" in model_schema_id:
+            request_data.update({"provider_model_id": test_data["provider_model_id"]})
+        try:
+            res = await asyncio.wait_for(chat_completion(request_data), timeout=120)
+        except asyncio.TimeoutError:
+            pytest.skip("Skipping test due to timeout after 2 minutes.")
+        if is_provider_service_error(res):
+            pytest.skip("Skip the test case with provider service error.")
+        res_json = res.json()
+        assert res.status_code == 200, res_json.get("error").get("message")
+        assert res_json.get("status") == "success"
+        assert res_json.get("data").get("finish_reason") == "stop"
+        assert res_json.get("data").get("message").get("role") == "assistant"
+        content = res_json.get("data").get("message").get("content")
+        assert content is not None
+        assert json.loads(content)
+        assert res_json.get("data").get("message").get("function_calls") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "test_data",
+        generate_test_cases("chat_completion") + generate_wildcard_test_cases("chat_completion"),
+        ids=lambda d: d["model_schema_id"],
+    )
+    @pytest.mark.flaky(reruns=5, reruns_delay=1)
+    async def test_chat_completion_by_stream_response_format(self, test_data):
+        if "response_format" not in test_data["allowed_configs"]:
+            pytest.skip("Skip the test case without response_format.")
+        model_schema_id = test_data["model_schema_id"]
+        message = [
+            {
+                "role": "user",
+                "content": "What does 42 mean"
+            }
+        ]
+        stream = test_data["stream"]
+        if not stream or "debug" in model_schema_id or "azure" in model_schema_id:
+            pytest.skip("Skip the test case without stream.")
+        configs = {
+            "temperature": 0.5,
+            "response_format": "json_object"
+
+        }
+        request_data = {
+            "model_schema_id": model_schema_id,
+            "messages": message,
+            "stream": True,
+            "configs": configs,
+        }
+        if "wildcard" in model_schema_id:
+            request_data.update({"provider_model_id": test_data["provider_model_id"]})
+
+        request_url = f"{Config.BASE_URL}/chat_completion"
+        default = False
+        content = ""
+        async for response_dict in sse_stream(request_url, request_data):
+            if response_dict.get("object") == "ChatCompletion":
+                assert response_dict.get("finish_reason") == "stop"
+                assert response_dict.get("message").get("role") == "assistant"
+                assert response_dict.get("message").get("content") is not None
+                assert response_dict.get("message").get("function_calls") is None
+                default = True
+            elif response_dict.get("object") == "ChatCompletionChunk":
+                assert response_dict.get("role") == "assistant"
+                assert response_dict.get("index") >= 0
+                assert response_dict.get("delta") is not None
+                content += response_dict.get("delta")
+            else:
+                assert False, f"response_dict={response_dict}"
+        assert default, "stream failed"
+        assert json.loads(content)
+


### PR DESCRIPTION
# Pull Request

## PR Description

Supports json mode for multiple chat completion model providers, including: 
- OpenAI
- Mistral
- TogetherAI
- Anthropic
- Google Gemini

## Linked Issue
Linked issue: #181 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Performance enhancement
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other, please describe:

## Checklist

Before submitting this PR, please make sure:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] I have tested my changes locally to ensure they are effective.
- [x] I have updated the necessary documentation (if applicable).
