### PR TITLE
fix: fix the pricing url of moonshot

### DIFF
--- a/inference/providers/moonshot/resources/provider.yml
+++ b/inference/providers/moonshot/resources/provider.yml
@@ -17,5 +17,5 @@ credentials_schema:
 resources:
   taskingai_documentation_url: "https://docs.tasking.ai/docs/integration/models/language_models/moonshot"
   official_site_url: "https://www.moonshot.cn/"
-  official_pricing_url: "https://platform.moonshot.cn/docs/pricing"
+  official_pricing_url: "https://platform.moonshot.cn/docs/price/pricing"
   official_credentials_url: "https://platform.moonshot.cn/console/api-keys"


### PR DESCRIPTION
# Pull Request

## PR Description

The original pricing URL for Moonshot returns a 404 error. The new pricing URL has been updated here.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance enhancement
- [ ] Code refactor
- [x] Documentation update
- [ ] Other, please describe:

## Checklist

Before submitting this PR, please make sure:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] I have tested my changes locally to ensure they are effective.
- [x] I have updated the necessary documentation (if applicable).