### PR TITLE
feat: add provider credentials verification func

### DIFF
--- a/inference/app/models/provider.py
+++ b/inference/app/models/provider.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Dict
 from .utils import i18n_text
+from app.models import ModelType
 
 __all__ = ["Provider"]
 
@@ -26,6 +27,9 @@ class Provider(BaseModel):
     enable_custom_headers: bool
     return_token_usage: bool
     return_stream_token_usage: bool
+    pass_provider_level_credential_check: bool
+    default_credential_verification_model_type: ModelType
+    default_credential_verification_provider_model_id: str
 
     @staticmethod
     def object_name():
@@ -50,6 +54,13 @@ class Provider(BaseModel):
                 enable_custom_headers=row.get("enable_custom_headers", False),
                 return_token_usage=row.get("return_token_usage", False),
                 return_stream_token_usage=row.get("return_stream_token_usage", False),
+                pass_provider_level_credential_check=row.get("pass_provider_level_credential_check", True),
+                default_credential_verification_model_type=row.get(
+                    "default_credential_verification_model_type", ModelType.WILDCARD
+                ),
+                default_credential_verification_provider_model_id=row.get(
+                    "default_credential_verification_provider_model_id", ""
+                ),
             )
         except KeyError as e:
             error_msg = f"Missing key '{e.args[0]}' for provider '{provider_id}'. Please check the data."

--- a/inference/app/routes/verify/schema.py
+++ b/inference/app/routes/verify/schema.py
@@ -58,3 +58,26 @@ class VerifyModelCredentialsSchema(BaseModel):
         "length is less than 64 and value's length is less than 512.",
         examples=[{"key1": "value1"}, {"key2": "value2"}],
     )
+
+
+class VerifyProviderCredentialsSchema(BaseModel):
+
+    provider_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=127,
+        description="The ID of the model schema.",
+        examples=["openai"],
+    )
+
+    credentials: Optional[Dict] = Field(
+        None,
+        description="The credentials of the model provider to be verified. "
+        "Only one of credentials or encrypted_credentials is required.",
+    )
+
+    encrypted_credentials: Optional[Dict] = Field(
+        None,
+        description="The encrypted credentials of the model provider to be verified.",
+        examples=[None],
+    )

--- a/inference/providers/ai21/resources/provider.yml
+++ b/inference/providers/ai21/resources/provider.yml
@@ -3,6 +3,10 @@ name: "i18n:ai21_name"
 description: "i18n:ai21_description"
 updated_timestamp: 1707152831000
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: j2-ultra
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/anthropic/resources/provider.yml
+++ b/inference/providers/anthropic/resources/provider.yml
@@ -9,6 +9,10 @@ enable_custom_headers: true
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: claude-3-sonnet
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/aws_bedrock/resources/provider.yml
+++ b/inference/providers/aws_bedrock/resources/provider.yml
@@ -3,6 +3,10 @@ name: "i18n:aws_bedrock_name"
 description: "i18n:aws_bedrock_description"
 updated_timestamp: 1707152831000
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: anthropic/claude-v2.1
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/azure_openai/resources/provider.yml
+++ b/inference/providers/azure_openai/resources/provider.yml
@@ -9,6 +9,10 @@ enable_custom_headers: true
 return_token_usage: true
 return_stream_token_usage: false
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: gpt-3.5-turbo
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/baichuan/resources/provider.yml
+++ b/inference/providers/baichuan/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1707152831000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: baichuan3-turbo
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/cohere/resources/provider.yml
+++ b/inference/providers/cohere/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1707152831000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: command
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/custom_host/resources/provider.yml
+++ b/inference/providers/custom_host/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1707152831000
 return_token_usage: false
 return_stream_token_usage: false
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: openai-function-call
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/debug/resources/provider.yml
+++ b/inference/providers/debug/resources/provider.yml
@@ -3,6 +3,10 @@ name: "i18n:debug_name"
 description: "i18n:debug_description"
 updated_timestamp: 1711074909
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: debug-chat-completion
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/deepseek/resources/provider.yml
+++ b/inference/providers/deepseek/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1716545924
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: deepseek-chat
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/fireworks/resources/provider.yml
+++ b/inference/providers/fireworks/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1722318984000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: text_embedding
+default_credential_verification_provider_model_id: gte-base
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/google_gemini/resources/provider.yml
+++ b/inference/providers/google_gemini/resources/provider.yml
@@ -9,6 +9,10 @@ enable_custom_headers: true
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: gemini-1.0-pro
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/groq/resources/provider.yml
+++ b/inference/providers/groq/resources/provider.yml
@@ -9,6 +9,10 @@ enable_custom_headers: true
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: gemma-7b
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/hugging_face/resources/provider.yml
+++ b/inference/providers/hugging_face/resources/provider.yml
@@ -6,6 +6,8 @@ updated_timestamp: 1707152831000
 return_token_usage: false
 return_stream_token_usage: false
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/hugging_face_inference_endpoint/resources/provider.yml
+++ b/inference/providers/hugging_face_inference_endpoint/resources/provider.yml
@@ -3,6 +3,8 @@ name: "i18n:hugging_face_inference_endpoint_name"
 description: "i18n:hugging_face_inference_endpoint_description"
 updated_timestamp: 1707152831000
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/jina/resources/provider.yml
+++ b/inference/providers/jina/resources/provider.yml
@@ -3,6 +3,10 @@ name: "i18n:jina_name"
 description: "i18n:jina_description"
 updated_timestamp: 1707152831000
 
+default_credential_verification_model_type: rerank
+default_credential_verification_provider_model_id: jina-reranker-v1-base-en
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/leptonai/resources/provider.yml
+++ b/inference/providers/leptonai/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1716431009
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: gemma-7b
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/llama_api/resources/provider.yml
+++ b/inference/providers/llama_api/resources/provider.yml
@@ -6,6 +6,8 @@ updated_timestamp: 1707152831000
 return_token_usage: true
 return_stream_token_usage: false
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/lm_studio/resources/provider.yml
+++ b/inference/providers/lm_studio/resources/provider.yml
@@ -3,6 +3,8 @@ name: "i18n:lm_studio_name"
 description: "i18n:lm_studio_description"
 updated_timestamp: 1707152831000
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/localai/resources/provider.yml
+++ b/inference/providers/localai/resources/provider.yml
@@ -3,6 +3,8 @@ name: "i18n:localai_name"
 description: "i18n:localai_description"
 updated_timestamp: 1707152831000
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/minimax/resources/provider.yml
+++ b/inference/providers/minimax/resources/provider.yml
@@ -3,6 +3,10 @@ name: "i18n:minimax_name"
 description: "i18n:minimax_description"
 updated_timestamp: 1713862809
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: abab5.5-chat
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/mistralai/resources/provider.yml
+++ b/inference/providers/mistralai/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1707152831000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: open-mistral-7b
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/moonshot/resources/provider.yml
+++ b/inference/providers/moonshot/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1711074909
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: moonshot-v1-8k
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/ollama/resources/provider.yml
+++ b/inference/providers/ollama/resources/provider.yml
@@ -3,6 +3,8 @@ name: "i18n:ollama_name"
 description: "i18n:ollama_description"
 updated_timestamp: 1707152831000
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/openai/resources/provider.yml
+++ b/inference/providers/openai/resources/provider.yml
@@ -9,6 +9,10 @@ enable_custom_headers: true
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: gpt-4o-mini
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/openrouter/resources/provider.yml
+++ b/inference/providers/openrouter/resources/provider.yml
@@ -6,6 +6,8 @@ updated_timestamp: 1716896559000
 return_token_usage: true
 return_stream_token_usage: true
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/reka/resources/provider.yml
+++ b/inference/providers/reka/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1716456299
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: reka-flash
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/replicate/resources/provider.yml
+++ b/inference/providers/replicate/resources/provider.yml
@@ -3,6 +3,8 @@ name: "i18n:replicate_name"
 description: "i18n:replicate_description"
 updated_timestamp: 1707152831000
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/sensetime/resources/models/sensechat-128k.yml
+++ b/inference/providers/sensetime/resources/models/sensechat-128k.yml
@@ -1,5 +1,5 @@
 model_schema_id: sensetime/sensechat-128k
-provider_model_id: SenseChat-128K
+provider_model_id: sensechat-128K
 type: chat_completion
 name: "i18n:sensechat_128k_name"
 description: "i18n:sensechat_128k_description"

--- a/inference/providers/sensetime/resources/models/sensechat-32k.yml
+++ b/inference/providers/sensetime/resources/models/sensechat-32k.yml
@@ -1,5 +1,5 @@
 model_schema_id: sensetime/sensechat-32k
-provider_model_id: SenseChat-32K
+provider_model_id: sensechat-32K
 type: chat_completion
 name: "i18n:sensechat_32k_name"
 description: "i18n:sensechat_32k_description"

--- a/inference/providers/sensetime/resources/models/sensechat-5.yml
+++ b/inference/providers/sensetime/resources/models/sensechat-5.yml
@@ -1,5 +1,5 @@
 model_schema_id: sensetime/sensechat-5
-provider_model_id: SenseChat-5
+provider_model_id: sensechat-5
 type: chat_completion
 name: "i18n:sensechat_5_name"
 description: "i18n:sensechat_5_description"

--- a/inference/providers/sensetime/resources/models/sensechat-functioncall.yml
+++ b/inference/providers/sensetime/resources/models/sensechat-functioncall.yml
@@ -1,5 +1,5 @@
 model_schema_id: sensetime/sensechat-functioncall
-provider_model_id: SenseChat-FunctionCall
+provider_model_id: sensechat-functioncall
 type: chat_completion
 name: "i18n:sensechat_functioncall_name"
 description: "i18n:sensechat_functioncall_description"

--- a/inference/providers/sensetime/resources/models/sensechat-turbo.yml
+++ b/inference/providers/sensetime/resources/models/sensechat-turbo.yml
@@ -1,5 +1,5 @@
 model_schema_id: sensetime/sensechat-turbo
-provider_model_id: SenseChat-Turbo
+provider_model_id: sensechat-turbo
 type: chat_completion
 name: "i18n:sensechat_turbo_name"
 description: "i18n:sensechat_turbo_description"

--- a/inference/providers/sensetime/resources/models/sensechat.yml
+++ b/inference/providers/sensetime/resources/models/sensechat.yml
@@ -1,5 +1,5 @@
 model_schema_id: sensetime/sensechat
-provider_model_id: SenseChat
+provider_model_id: sensechat
 type: chat_completion
 name: "i18n:sensechat_name"
 description: "i18n:sensechat_description"

--- a/inference/providers/sensetime/resources/provider.yml
+++ b/inference/providers/sensetime/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1716974560000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: sensechat
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/siliconcloud/resources/provider.yml
+++ b/inference/providers/siliconcloud/resources/provider.yml
@@ -6,6 +6,8 @@ updated_timestamp: 1719373812000
 return_token_usage: true
 return_stream_token_usage: true
 
+pass_provider_level_credential_check: true
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/togetherai/resources/provider.yml
+++ b/inference/providers/togetherai/resources/provider.yml
@@ -9,6 +9,10 @@ enable_custom_headers: true
 return_token_usage: true
 return_stream_token_usage: false
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: meta-llama/Llama-2-70b-chat-hf
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/tongyi/resources/provider.yml
+++ b/inference/providers/tongyi/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1707152831000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: qwen-turbo
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/volcengine/resources/provider.yml
+++ b/inference/providers/volcengine/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1716342841
 return_token_usage: true
 return_stream_token_usage: false
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: doubao-lite-4k
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/wenxin/resources/provider.yml
+++ b/inference/providers/wenxin/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1708236934318
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: ernie-bot
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/yi/resources/provider.yml
+++ b/inference/providers/yi/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1707152831000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: yi-spark
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/providers/zhipu/resources/provider.yml
+++ b/inference/providers/zhipu/resources/provider.yml
@@ -6,6 +6,10 @@ updated_timestamp: 1707152831000
 return_token_usage: true
 return_stream_token_usage: true
 
+default_credential_verification_model_type: chat_completion
+default_credential_verification_provider_model_id: glm-3-turbo
+pass_provider_level_credential_check: false
+
 credentials_schema:
   type: object
   properties:

--- a/inference/test/inference_service/inference.py
+++ b/inference/test/inference_service/inference.py
@@ -32,6 +32,13 @@ async def verify_credentials(data: Dict):
         return ResponseWrapper(response.status, await response.json())
 
 
+async def verify_provider_credentials(data: Dict):
+    async with aiohttp.ClientSession() as session:
+        request_url = f"{Config.BASE_URL}/verify_provider_credentials"
+        response = await session.post(request_url, json=data)
+        return ResponseWrapper(response.status, await response.json())
+
+
 async def caches():
     async with aiohttp.ClientSession() as session:
         request_url = f"{Config.BASE_URL}/caches"


### PR DESCRIPTION
# Pull Request

## PR Description

**Add Provider Credential Verification Feature**
This update introduces provider credential verification functionality. The model testing types supported include: `chat_completion`, `text_embedding`, and `rerank`. Providers with a model type of `wildcard` are excluded from this verification process.

When `pass_provider_level_credential_check` is set to `true`, the verification is skipped for the specified provider. The default value for this setting is `true`.

**Additional settings:**
`default_credential_verification_model_type`: Defaults to `wildcard`
`default_credential_verification_provider_model_id`: Specifies the model ID used for verification


**Excluded Providers**
The following providers are skipped in the verification process(wildcard): `hugging_face`, `hugging_face_inference_endpoint`, `llama_api`, `lm_studio`, `localai`, `ollama`, `openrouter`, `replicate`, and `siliconcloud`

**Testing Types for Specific Providers**
For `text_embedding `model type: `fireworks`
For `rerank `model type: `jina`
All other providers use `chat_completion `as the default testing model

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Performance enhancement
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other, please describe:

## Checklist

Before submitting this PR, please make sure:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] I have tested my changes locally to ensure they are effective.
- [x] I have updated the necessary documentation (if applicable).